### PR TITLE
feat(chat): add reply functionality to chat messages

### DIFF
--- a/app/components/chat/AssistantMessage.tsx
+++ b/app/components/chat/AssistantMessage.tsx
@@ -18,6 +18,7 @@ interface AssistantMessageProps {
   messageId?: string;
   onRewind?: (messageId: string) => void;
   onFork?: (messageId: string) => void;
+  onReply?: (messageId: string, content: string) => void;
   append?: (message: Message) => void;
   chatMode?: 'discuss' | 'build';
   setChatMode?: (mode: 'discuss' | 'build') => void;
@@ -92,6 +93,7 @@ export const AssistantMessage = memo(
     messageId,
     onRewind,
     onFork,
+    onReply,
     append,
     chatMode,
     setChatMode,
@@ -150,8 +152,17 @@ export const AssistantMessage = memo(
                 </div>
               </div>
               )}
-              {(onRewind || onFork) && messageId && (
+              {(onRewind || onFork || onReply) && messageId && (
                 <div className="flex gap-2 flex-col lg:flex-row ml-auto">
+                  {onReply && (
+                    <WithTooltip tooltip="Répondre à ce message">
+                      <button
+                        onClick={() => onReply(messageId, content)}
+                        key="i-ph:arrow-bend-up-left"
+                        className="i-ph:arrow-bend-up-left text-xl text-bolt-elements-textSecondary hover:text-bolt-elements-textPrimary transition-colors"
+                      />
+                    </WithTooltip>
+                  )}
                   {onRewind && (
                     <WithTooltip tooltip="Revert to this message">
                       <button

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -81,6 +81,9 @@ interface BaseChatProps {
   selectedElement?: ElementInfo | null;
   setSelectedElement?: (element: ElementInfo | null) => void;
   runAnimation?: () => void;
+  onReply?: (messageId: string, content: string) => void;
+  replyToMessage?: {id: string, content: string} | null;
+  setReplyToMessage?: (reply: {id: string, content: string} | null) => void;
 
 }
 
@@ -128,6 +131,9 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       selectedElement,
       setSelectedElement,
       runAnimation,
+      onReply,
+      replyToMessage,
+      setReplyToMessage,
     },
     ref,
   ) => {
@@ -419,6 +425,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                         setChatMode={setChatMode}
                         provider={provider}
                         model={model}
+                        onReply={onReply}
                       />
                     ) : null
                   }
@@ -505,9 +512,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                   designScheme={designScheme}
                   setDesignScheme={setDesignScheme}
                   selectedElement={selectedElement}
-                  setSelectedElement={setSelectedElement}
-                  runAnimation={runAnimation}
-                />
+                        setSelectedElement={setSelectedElement}
+                        runAnimation={runAnimation}
+                        replyToMessage={replyToMessage}
+                        setReplyToMessage={setReplyToMessage}
+                      />
               </div>
             </StickToBottom>
             <div className="flex flex-col justify-center">

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -155,6 +155,7 @@ export const ChatImpl = memo(
     const [chatMode, setChatMode] = useState<'discuss' | 'build'>('build');
      // Keep track of the errors we alerted on. useChat gets the same data twice even if they're removed with setData
      const [selectedElement, setSelectedElement] = useState<ElementInfo | null>(null);
+     const [replyToMessage, setReplyToMessage] = useState<{id: string, content: string} | null>(null);
      const alertedErrorIds = useRef(new Set());
     const {
       messages,
@@ -323,6 +324,14 @@ export const ChatImpl = memo(
       setChatStarted(true);
     };
 
+    const handleReply = (messageId: string, content: string) => {
+      setReplyToMessage({ id: messageId, content });
+      // Optionally scroll to the input area or focus it
+      if (textareaRef.current) {
+        textareaRef.current.focus();
+      }
+    };
+
     const sendMessage = async (_event: React.UIEvent, messageInput?: string) => {
       const messageContent = messageInput || input;
 
@@ -349,6 +358,12 @@ export const ChatImpl = memo(
         contextSection += '\n--- FIN CONTEXTE ---\n\n';
       }
       let finalMessageContent = messageContent;
+
+      // Add reply context if replying to a message
+      if (replyToMessage) {
+        finalMessageContent = `En réponse au message: "${replyToMessage.content.substring(0, 200)}${replyToMessage.content.length > 200 ? '...' : ''}"\n\n${finalMessageContent}`;
+        setReplyToMessage(null); // Clear reply context after sending
+      }
 
       if (selectedElement) {
         console.log('Selected Element:', selectedElement);
@@ -618,6 +633,9 @@ export const ChatImpl = memo(
         selectedElement={selectedElement}
         setSelectedElement={setSelectedElement}
         runAnimation={runAnimation}
+        onReply={handleReply}
+        replyToMessage={replyToMessage}
+        setReplyToMessage={setReplyToMessage}
       />
     );
   },

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -71,6 +71,8 @@ interface ChatBoxProps {
   selectedElement?: ElementInfo | null;
   setSelectedElement?: ((element: ElementInfo | null) => void) | undefined;
   runAnimation?: () => void;
+  replyToMessage?: {id: string, content: string} | null;
+  setReplyToMessage?: (reply: {id: string, content: string} | null) => void;
 }
 
 export const ChatBox: React.FC<ChatBoxProps> = (props) => {
@@ -133,6 +135,23 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
         <rect className={classNames(styles.PromptShine)} x="48" y="24" width="70" height="1"></rect>
       </svg>
       <div>
+        {props.replyToMessage && (
+        <div className="flex mx-1.5 gap-2 items-center justify-between rounded-lg rounded-b-none border border-b-none border-bolt-elements-borderColor text-bolt-elements-textPrimary flex py-1 px-2.5 font-medium text-xs bg-blue-50 dark:bg-blue-900/20">
+          <div className="flex gap-2 items-center">
+            <div className="i-ph:arrow-bend-up-left text-blue-500 w-4 h-4"></div>
+            <span className="text-blue-600 dark:text-blue-400">Réponse à:</span>
+            <span className="text-bolt-elements-textSecondary truncate max-w-[200px]">
+              {props.replyToMessage.content.substring(0, 50)}{props.replyToMessage.content.length > 50 ? '...' : ''}
+            </span>
+          </div>
+          <button
+            className="bg-transparent text-blue-500 hover:text-blue-700 pointer-auto ml-[-20px]"
+            onClick={() => props.setReplyToMessage?.(null)}
+          >
+            ✕
+          </button>
+        </div>
+      )}
         {props.selectedElement && (
         <div className="flex mx-1.5 gap-2 items-center justify-between rounded-lg rounded-b-none border border-b-none border-bolt-elements-borderColor text-bolt-elements-textPrimary flex py-1 px-2.5 font-medium text-xs">
           <div className="flex gap-2 items-center lowercase">

--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -22,6 +22,7 @@ interface MessagesProps {
   setChatMode?: (mode: 'discuss' | 'build') => void;
   model?: string;
   provider?: ProviderInfo;
+  onReply?: (messageId: string, content: string) => void;
 }
 
 export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
@@ -47,6 +48,12 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
         window.location.href = `/chat/${urlId}`;
       } catch (error) {
         toast.error('Failed to fork chat: ' + (error as Error).message);
+      }
+    };
+
+    const handleReply = (messageId: string, content: string) => {
+      if (props.onReply) {
+        props.onReply(messageId, content);
       }
     };
 
@@ -85,6 +92,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
                         messageId={messageId}
                         onRewind={handleRewind}
                         onFork={handleFork}
+                        onReply={handleReply}
                         append={props.append}
                         chatMode={props.chatMode}
                         setChatMode={props.setChatMode}


### PR DESCRIPTION
Implement the ability to reply to specific messages in the chat interface. This includes:
- Adding onReply callback prop through the component hierarchy
- Displaying a reply indicator in the chat box
- Including the replied message content in new messages
- Allowing users to cancel a reply