### PR TITLE
Fix prompt typos and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,15 +866,6 @@ pnpm electron:build:dist
 > 
 > 🚀 **CI/CD** : Pipeline de déploiement intelligent
 
-### Personnaliser le prompt système
-
-NeuroCode propose plusieurs invites système pour orienter l'IA :
-- `default` : prompt officiel optimisé.
-- `original` : prompt historique.
-- `optimized` : version expérimentale.
-
-Vous pouvez choisir le prompt dans l'onglet **Paramètres** de l'application.
-Pour créer de nouvelles invites, ajoutez-les dans `app/lib/common/prompt-library.ts`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -866,6 +866,16 @@ pnpm electron:build:dist
 > 
 > 🚀 **CI/CD** : Pipeline de déploiement intelligent
 
+### Personnaliser le prompt système
+
+NeuroCode propose plusieurs invites système pour orienter l'IA :
+- `default` : prompt officiel optimisé.
+- `original` : prompt historique.
+- `optimized` : version expérimentale.
+
+Vous pouvez choisir le prompt dans l'onglet **Paramètres** de l'application.
+Pour créer de nouvelles invites, ajoutez-les dans `app/lib/common/prompt-library.ts`.
+
 ---
 
 ## 🤝 Contribution

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -118,7 +118,7 @@ export async function streamText(props: {
   );
 
   let systemPrompt =
-    PromptLibrary.getPropmtFromLibrary(promptId || 'default', {
+    PromptLibrary.getPromptFromLibrary(promptId || 'default', {
       cwd: WORK_DIR,
       allowedHtmlElements: allowedHTMLElements,
       modificationTagName: MODIFICATIONS_TAG_NAME,

--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -53,11 +53,11 @@ export class PromptLibrary {
       };
     });
   }
-  static getPropmtFromLibrary(promptId: string, options: PromptOptions) {
+  static getPromptFromLibrary(promptId: string, options: PromptOptions) {
     const prompt = this.library[promptId];
 
     if (!prompt) {
-      throw 'Prompt Now Found';
+      throw 'Prompt Not Found';
     }
 
     return this.library[promptId]?.get(options);

--- a/app/lib/common/prompts/new-prompt.ts
+++ b/app/lib/common/prompts/new-prompt.ts
@@ -1,3 +1,8 @@
+/**
+ * Main system prompt used by NeuroCode.
+ * getFineTunedPrompt is the default prompt accessed via PromptLibrary.
+ * Adjust <response_requirements> or <system_constraints> sections to tweak behaviour.
+ */
 import type { DesignScheme } from '~/types/design-scheme';
 import { WORK_DIR } from '~/utils/constants';
 import { allowedHTMLElements } from '~/utils/markdown';

--- a/app/lib/common/prompts/optimized.ts
+++ b/app/lib/common/prompts/optimized.ts
@@ -12,7 +12,7 @@ You are NeuroCode, an expert AI assistant and exceptional senior software develo
   - Prefer Node.js scripts over shell scripts
   - Use Vite for web servers
   - Databases: prefer libsql, sqlite, or non-native solutions
-  - When for react dont forget to write vite config and index.html to the project
+  - When using React, include a Vite configuration and an `index.html` file in the project
   - WebContainer CANNOT execute diff or patch editing so always write your code in full no partial/diff update
 
   Available shell commands: cat, cp, ls, mkdir, mv, rm, rmdir, touch, hostname, ps, pwd, uptime, env, node, python3, code, jq, curl, head, sort, tail, clear, which, export, chmod, scho, kill, ln, xxd, alias, getconf, loadenv, wasm, xdg-open, command, exit, source

--- a/app/lib/common/prompts/optimized.ts
+++ b/app/lib/common/prompts/optimized.ts
@@ -278,7 +278,7 @@ You are NeuroCode, an expert AI assistant and exceptional senior software develo
     - \`file\`: For writing/updating files (include \`filePath\` attribute)
     - \`start\`: For starting dev servers (use only when necessary/ or new dependencies are installed)
 24. Order actions logically - dependencies MUST be installed first
-25. For Vite project must include vite config and index.html for entry point
+25. For Vite projects, include a `vite.config.ts` file and an `index.html` entry point
 26. Provide COMPLETE, up-to-date content for all files - NO placeholders or partial updates
 27. WebContainer CANNOT execute diff or patch editing so always write your code in full no partial/diff update
 

--- a/app/lib/common/prompts/small-llm-optimized.ts
+++ b/app/lib/common/prompts/small-llm-optimized.ts
@@ -276,7 +276,7 @@ Ensure correct XML-like structure for tags.
     - \`file\`: For writing/updating files (include \`filePath\` attribute)
     - \`start\`: For starting dev servers (use only when necessary/ or new dependencies are installed)
 13. Order actions logically - dependencies MUST be installed first
-14. For Vite project must include vite config and index.html for entry point
+14. For Vite projects, include a `vite.config.ts` file and an `index.html` entry point
 
 CRITICAL: These rules are ABSOLUTE and MUST be followed WITHOUT EXCEPTION in EVERY response.
 

--- a/app/lib/common/prompts/small-llm-optimized.ts
+++ b/app/lib/common/prompts/small-llm-optimized.ts
@@ -12,7 +12,7 @@ You are NeuroCode, an expert AI assistant and exceptional senior software develo
   - Prefer Node.js scripts over shell scripts
   - Use Vite for web servers
   - Databases: prefer libsql, sqlite, or non-native solutions
-  - When for react dont forget to write vite config and index.html to the project
+  - When using React, include a Vite configuration and an `index.html` file in the project
   - WebContainer CANNOT execute diff or patch editing so always write your code in full no partial/diff update
 
   Available shell commands: cat, cp, ls, mkdir, mv, rm, rmdir, touch, hostname, ps, pwd, uptime, env, node, python3, code, jq, curl, head, sort, tail, clear, which, export, chmod, scho, kill, ln, xxd, alias, getconf, loadenv, wasm, xdg-open, command, exit, source


### PR DESCRIPTION
## Summary
- correct PromptLibrary API typo and update usage
- clarify React instructions in optimized prompts
- document prompt customization in README
- note default prompt behavior in new-prompt.ts

## Testing
- `pnpm lint` *(fails: prettier issues)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68496e1f92a4832684e1a94feed62fec