### PR TITLE
Handle missing prompts gracefully

### DIFF
--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -57,9 +57,9 @@ export class PromptLibrary {
     const prompt = this.library[promptId];
 
     if (!prompt) {
-      throw 'Prompt Now Found';
+      return undefined;
     }
 
-    return this.library[promptId]?.get(options);
+    return prompt.get(options);
   }
 }


### PR DESCRIPTION
## Summary
- allow falling back to default prompt when a prompt ID is unknown

## Testing
- `pnpm run lint` *(fails: 3558 errors)*
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68497797fd0c8326bf3c2acf457708a0